### PR TITLE
Make Block-Dev work with multiple targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,103 @@
-# Crail on shared volume block deviceCrail-blkdev is an extension of the crail project to enable itto run on shared volume block devices.## BuildingClone and build [`jaio`](https://www.github.com/zrlio/jaio) dependency.Clone and build the project using:```bashmvn -DskipTests install```Then copy the jar files crail-blkdev-1.0.jar and its dependencies from the`target`folder into`$CRAIL_HOME/jars/`.Alternatively you can also put these files in your custom classpath.## Configuration parametersThe current code accepts following parameters (shown with their defaut values):```crail.storage.blkdev.datapath          /dev/blkdevcrail.storage.blkdev.storagelimit      1073741824crail.storage.blkdev.allocationsize    1073741824crail.storage.blkdev.queuedepth        16```You can put these values in `$CRAIL_HOME/conf/crail-site.conf`.## Starting a crail-blkdev datanode To start a crail-blkdev datanode, start a datanodes as ```bash $CRAIL_HOME/bin/crail datanode -t com.ibm.crail.storage.blkdev.BlkDevStorageTier```in order for a client to automatically pick up connection to a new datanode type, you have to add following class to your list of datanode types in the`$CRAIL_HOME/conf/crail-site.conf` file. An example of such entry is :```bashcrail.storage.types  com.ibm.crail.storage.rdma.RdmaDataNode,com.ibm.crail.storage.blkdev.BlkDevStorageTier```Please note that, this is a comma separated list of datanode **types** which defines the priorty order as well in which the blocks from a datanode will be consumed by the namenode. ## Setting up automatic deploymentTo enable deployment via `$CRAIL_HOME/bin/start-crail.sh` use the following extension in the crail slave file (`$CRAIL_HOME/conf/slave`.): ```bashhostname1 -t com.ibm.crail.storage.blkdev.BlkDevStorageTier...```Note: A crail-blkdev datanode does not serve data requests from clients, butonly registers the block device storage information to the namenode. Such thatclients can directly access shared volume block devices with the offset information providedby the namenode.## Alignment requirementsThe crail block device client depends on jaio which requires buffers to be aligned toblock size (512B). For any application using the crail block device client you needto set the aligned direct memory option of the JVM:```-Dsun.nio.PageAlignDirectMemory=true```For example, in spark you can set the property `spark.executor.extraJavaOptions` in`spark-defaults.conf`.## ContributionsPRs are always welcome. Please fork, and make necessary modifications you propose, and let us know.## ContactIf you have questions or suggestions, feel free to post at:https://groups.google.com/forum/#!forum/zrlio-usersor email: zrlio-users@googlegroups.com  
+# Crail on shared volume block device
+
+Crail-blkdev is an extension of the crail project to enable it
+to run on shared volume block devices.
+
+## Building
+
+Clone and build [`jaio`](https://www.github.com/zrlio/jaio) dependency.
+Clone and build the project using:
+
+```bash
+mvn -DskipTests install
+```
+Then copy the jar files crail-blkdev-1.0.jar and its dependencies from the
+`target`folder into`$CRAIL_HOME/jars/`.
+
+Alternatively you can also put these files in your custom classpath.
+
+## Configuration parameters
+There are two sets of parameters for a blk-device: client and target
+
+The target parameters are as follows (shown with default values):
+```
+crail.storage.blkdev.storagesize	1073741824
+crail.storage.blkdev.allocationsize	1048576
+crail.storage.blkdev.interface		eth5
+crail.storage.blkdev.port		12345
+```
+
+The client parameters are as follows (shown with default values):
+```
+crail.storage.blkdev.datapath		/dev/vdev1,/dev/vdev2
+crail.storage.blkdev.dataipport		12.12.12.62:54321,12.12.12.63:12345
+crail.storage.blkdev.storagelimit	2147483648
+crail.storage.blkdev.queuedepth 	8
+```
+
+The columns in in the datapath and dataipport parameters reflect the mapping
+that client has already setup between a target block device and local virtual
+block device. For example, in the configuration above, on the target a block
+device is exposed on interface eth5 (12.12.12.63) and port 12345. The client
+has mapped this remove block device to path /dev/vdev2, with a protocol such
+as iSCSI. The first column of dataipport and datapath reflect a different
+block device target.
+
+Additionally, the storagelimit should be a sum of the capacaity of all the
+block-device storage targets.
+
+You can put these values in `$CRAIL_HOME/conf/crail-site.conf`.
+
+## Starting a crail-blkdev datanode
+To start a crail-blkdev datanode, start a datanodes as
+```bash
+$CRAIL_HOME/bin/crail datanode -t com.ibm.crail.storage.blkdev.BlkDevStorageTier
+```
+in order for a client to automatically pick up connection to a new datanode
+type, you have to add following class to your list of datanode types in the
+`$CRAIL_HOME/conf/crail-site.conf` file. An example of such entry is :
+
+```bash
+crail.storage.types  com.ibm.crail.storage.rdma.RdmaDataNode,com.ibm.crail.storage.blkdev.BlkDevStorageTier
+```
+
+Please note that, this is a comma separated list of datanode **types** which
+defines the priorty order as well in which the blocks from a datanode will
+be consumed by the namenode.
+
+## Setting up automatic deployment
+
+To enable deployment via `$CRAIL_HOME/bin/start-crail.sh` use the following extension
+in the crail slave file (`$CRAIL_HOME/conf/slave`.):
+
+```bash
+hostname1 -t com.ibm.crail.storage.blkdev.BlkDevStorageTier
+...
+```
+Note: A crail-blkdev datanode does not serve data requests from clients, but
+only registers the block device storage information to the namenode. Such that
+clients can directly access shared volume block devices with the offset information provided
+by the namenode.
+
+## Alignment requirements
+
+The crail block device client depends on jaio which requires buffers to be aligned to
+block size (512B). For any application using the crail block device client you need
+to set the aligned direct memory option of the JVM:
+```
+-Dsun.nio.PageAlignDirectMemory=true
+```
+For example, in spark you can set the property `spark.executor.extraJavaOptions` in
+`spark-defaults.conf`.
+
+## Contributions
+
+PRs are always welcome. Please fork, and make necessary modifications you propose, and let us know.
+
+## Contact
+
+If you have questions or suggestions, feel free to post at:
+
+https://groups.google.com/forum/#!forum/zrlio-users
+
+or email: zrlio-users@googlegroups.com

--- a/README.md
+++ b/README.md
@@ -23,27 +23,28 @@ The target parameters are as follows (shown with default values):
 ```
 crail.storage.blkdev.storagesize	1073741824
 crail.storage.blkdev.allocationsize	1048576
-crail.storage.blkdev.interface		eth5
+crail.storage.blkdev.ip         12.12.12.63
 crail.storage.blkdev.port		12345
 ```
 
 The client parameters are as follows (shown with default values):
 ```
-crail.storage.blkdev.datapath		/dev/vdev1,/dev/vdev2
-crail.storage.blkdev.dataipport		12.12.12.62:54321,12.12.12.63:12345
+crail.storage.blkdev.path		/dev/vdev1,/dev/vdev2
+crail.storage.blkdev.ipport		12.12.12.62:54321,12.12.12.63:12345
 crail.storage.blkdev.storagelimit	2147483648
 crail.storage.blkdev.queuedepth 	8
 ```
 
-The columns in in the datapath and dataipport parameters reflect the mapping
-that client has already setup between a target block device and local virtual
-block device. For example, in the configuration above, on the target a block
-device is exposed on interface eth5 (12.12.12.63) and port 12345. The client
-has mapped this remove block device to path /dev/vdev2, with a protocol such
-as iSCSI. The first column of dataipport and datapath reflect a different
-block device target.
+The columns in in the path and ipport parameters reflect the mapping (iSCSI) that
+client has already setup between a target block device and local virtual block
+device; this is why there is no device specified on the target side. For
+example, in the configuration above, on the target, a block device
+is exposed at ip address 12.12.12.63 and port 12345. The client has already
+mapped this remote block device to path /dev/vdev2, with a protocol such as
+iSCSI.
 
-Additionally, the storagelimit should be a sum of the capacaity of all the
+Each column in ipport and path reflect at different block device
+target. Additionally, the storagelimit should be a sum of the capacity of all the
 block-device storage targets.
 
 You can put these values in `$CRAIL_HOME/conf/crail-site.conf`.
@@ -101,3 +102,4 @@ If you have questions or suggestions, feel free to post at:
 https://groups.google.com/forum/#!forum/zrlio-users
 
 or email: zrlio-users@googlegroups.com
+block device target.

--- a/src/main/java/com/ibm/crail/storage/blkdev/BlkDevStorageClient.java
+++ b/src/main/java/com/ibm/crail/storage/blkdev/BlkDevStorageClient.java
@@ -8,22 +8,87 @@ import com.ibm.crail.utils.CrailUtils;
 import com.ibm.crail.storage.blkdev.client.BlkDevStorageEndpoint;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+import java.util.HashMap;
+import java.util.List;
 import org.slf4j.Logger;
 
 public class BlkDevStorageClient implements StorageClient{
     private static final Logger LOG = CrailUtils.getLogger();
+	private HashMap<Long, String> nodeMap;
 
 	public void printConf(Logger logger) {
-		BlkDevStorageConstants.printConf(logger);
+		BlkDevStorageConstants.printClientConf(logger);
 	}
 
+	private long convertIPPortToKey(String ipPort) throws IOException {
+		//The first token is the ip and the second is the port
+		StringTokenizer tokenizer = new StringTokenizer(ipPort, ":");
+		String ip = tokenizer.nextToken();
+		byte[] bytes = InetAddress.getByName(ip).getAddress();
+		int port = Integer.parseInt(tokenizer.nextToken());
+
+		return DataNodeInfo.calcKey(bytes, port);	
+	}
+
+	/*
+	 * Read the comma seperated lists of virtual device paths and their corresponding datanodes
+	 * (IP/ports) from the configuration file, creating a map from the key (IP/port) to virtual
+	 * device path. This is map is then consulted to identify the virtual device to when an Endpoint
+	 * is created.
+	 */
+	private void createHT() throws IOException {
+		nodeMap  = new HashMap<Long, String>();
+		
+		StringTokenizer tokenizer = new StringTokenizer(BlkDevStorageConstants.DATA_PATH, ",");
+		if (!tokenizer.hasMoreTokens()){
+			throw new IOException("No data paths defined!");
+		}
+
+		// read the list of virtual device paths
+		List<String> devList= new ArrayList();
+		while (tokenizer.hasMoreTokens()) {
+			String devName = tokenizer.nextToken();
+			devList.add(devName);
+		}
+
+		// read the list of ip/ports
+		tokenizer = new StringTokenizer(BlkDevStorageConstants.DATA_IP_PORT, ",");
+		if (!tokenizer.hasMoreTokens()){
+			throw new IOException("No IP/ports defined!");
+		}
+
+		List<Long> hashList = new ArrayList();
+		while (tokenizer. hasMoreTokens()) {
+			Long key = convertIPPortToKey(tokenizer.nextToken());
+			hashList.add(key);
+		}
+
+		if (hashList.size() != devList.size()){
+			throw new IOException("Device and ip/port list must be the same size" +
+				hashList.size() + ":" + devList.size());
+		}
+
+		// Add the tuples into the hashMap
+		for (int i = 0; i <devList.size(); i++) {
+			Long hash = hashList.get(i);
+			String devName = devList.get(i);
+			nodeMap.put(hash,devName);
+		}
+	}
+
+
 	public void init(CrailConfiguration crailConfiguration, String[] args) throws IOException {
-		BlkDevStorageConstants.updateConstants(crailConfiguration);
+		BlkDevStorageConstants.updateClientConstants(crailConfiguration);
+		createHT();
 		BlkDevStorageConstants.verify();
 	}
 
 	public StorageEndpoint createEndpoint(DataNodeInfo info) throws IOException {
-		return new BlkDevStorageEndpoint();
+		String vDevPath = nodeMap.get(info.key());
+		return new BlkDevStorageEndpoint(vDevPath);
 	}
 
 	public void close() throws Exception {

--- a/src/main/java/com/ibm/crail/storage/blkdev/BlkDevStorageClient.java
+++ b/src/main/java/com/ibm/crail/storage/blkdev/BlkDevStorageClient.java
@@ -8,86 +8,25 @@ import com.ibm.crail.utils.CrailUtils;
 import com.ibm.crail.storage.blkdev.client.BlkDevStorageEndpoint;
 
 import java.io.IOException;
-import java.net.InetAddress;
-import java.util.ArrayList;
-import java.util.StringTokenizer;
 import java.util.HashMap;
-import java.util.List;
 import org.slf4j.Logger;
 
 public class BlkDevStorageClient implements StorageClient{
-    private static final Logger LOG = CrailUtils.getLogger();
 	private HashMap<Long, String> nodeMap;
 
 	public void printConf(Logger logger) {
 		BlkDevStorageConstants.printClientConf(logger);
 	}
 
-	private long convertIPPortToKey(String ipPort) throws IOException {
-		//The first token is the ip and the second is the port
-		StringTokenizer tokenizer = new StringTokenizer(ipPort, ":");
-		String ip = tokenizer.nextToken();
-		byte[] bytes = InetAddress.getByName(ip).getAddress();
-		int port = Integer.parseInt(tokenizer.nextToken());
-
-		return DataNodeInfo.calcKey(bytes, port);	
-	}
-
-	/*
-	 * Read the comma seperated lists of virtual device paths and their corresponding datanodes
-	 * (IP/ports) from the configuration file, creating a map from the key (IP/port) to virtual
-	 * device path. This is map is then consulted to identify the virtual device to when an Endpoint
-	 * is created.
-	 */
-	private void createHT() throws IOException {
-		nodeMap  = new HashMap<Long, String>();
-		
-		StringTokenizer tokenizer = new StringTokenizer(BlkDevStorageConstants.DATA_PATH, ",");
-		if (!tokenizer.hasMoreTokens()){
-			throw new IOException("No data paths defined!");
-		}
-
-		// read the list of virtual device paths
-		List<String> devList= new ArrayList();
-		while (tokenizer.hasMoreTokens()) {
-			String devName = tokenizer.nextToken();
-			devList.add(devName);
-		}
-
-		// read the list of ip/ports
-		tokenizer = new StringTokenizer(BlkDevStorageConstants.DATA_IP_PORT, ",");
-		if (!tokenizer.hasMoreTokens()){
-			throw new IOException("No IP/ports defined!");
-		}
-
-		List<Long> hashList = new ArrayList();
-		while (tokenizer. hasMoreTokens()) {
-			Long key = convertIPPortToKey(tokenizer.nextToken());
-			hashList.add(key);
-		}
-
-		if (hashList.size() != devList.size()){
-			throw new IOException("Device and ip/port list must be the same size" +
-				hashList.size() + ":" + devList.size());
-		}
-
-		// Add the tuples into the hashMap
-		for (int i = 0; i <devList.size(); i++) {
-			Long hash = hashList.get(i);
-			String devName = devList.get(i);
-			nodeMap.put(hash,devName);
-		}
-	}
-
-
 	public void init(CrailConfiguration crailConfiguration, String[] args) throws IOException {
-		BlkDevStorageConstants.updateClientConstants(crailConfiguration);
-		createHT();
+		nodeMap  = new HashMap<Long, String>();
+		BlkDevStorageConstants.updateClientConstants(nodeMap, crailConfiguration);
 		BlkDevStorageConstants.verify();
 	}
 
 	public StorageEndpoint createEndpoint(DataNodeInfo info) throws IOException {
-		String vDevPath = nodeMap.get(info.key());
+		long key = BlkDevStorageConstants.calcKey(info.getIpAddress(), info.getPort());
+		String vDevPath = nodeMap.get(key);
 		return new BlkDevStorageEndpoint(vDevPath);
 	}
 

--- a/src/main/java/com/ibm/crail/storage/blkdev/BlkDevStorageConstants.java
+++ b/src/main/java/com/ibm/crail/storage/blkdev/BlkDevStorageConstants.java
@@ -27,14 +27,19 @@ import com.ibm.crail.conf.CrailConstants;
 import org.slf4j.Logger;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.StringTokenizer;
 
 public class BlkDevStorageConstants {
 
 	private final static String PREFIX = "crail.storage.blkdev";
 
 	// target:interface to access storage device
-	public static final String STORAGE_BLKDEV_INTERFACE_KEY = "interface";
-	public static String STORAGE_BLKDEV_INTERFACE = "eth5";
+	public static final String STORAGE_BLKDEV_IP_KEY = "ip";
+	public static String STORAGE_BLKDEV_IP= "127.0.0.1";
 
 	// target port to access storage device
 	public static final String STORAGE_BLKDEV_PORT_KEY = "port";
@@ -48,12 +53,12 @@ public class BlkDevStorageConstants {
 	public static final String ALLOCATION_SIZE_KEY = "allocationsize";
 	public static long ALLOCATION_SIZE = 1048576; /* 1MB */
 
-	// client Blk-Dev datanode list (device path)
-	public static final String DATA_PATH_KEY = "datapath";
+	// client: Blk-Dev datanode list (device path)
+	public static final String DATA_PATH_KEY = "path";
 	public static String DATA_PATH;
 
 	// client: Blk-dev datanode list (ip/port)
-	public static final String DATA_IP_PORT_KEY = "dataipport";
+	public static final String DATA_IP_PORT_KEY = "ipport";
 	public static String DATA_IP_PORT;
 
 	// client
@@ -73,11 +78,26 @@ public class BlkDevStorageConstants {
 		return conf.get(fullKey(key));
 	}
 
+	private static long convertIPPortToKey(String ipPort) throws IOException {
+		//The first token is the ip and the second is the port
+		StringTokenizer tokenizer = new StringTokenizer(ipPort, ":");
+		String ip = tokenizer.nextToken();
+		byte[] bytes = InetAddress.getByName(ip).getAddress();
+		int port = Integer.parseInt(tokenizer.nextToken());
+		return calcKey(bytes, port);
+	}
+
+	public static long calcKey(byte[] ip, int portNum) {
+		int a = java.util.Arrays.hashCode(ip);
+		long localKey = (((long)a) << 32) | (portNum & 0xffffffffL);
+		return localKey;
+	}
+
 	/*
 	 * Called only from the client side to map device names to block
 	 * device servers.
 	 */
-	public static void updateClientConstants(CrailConfiguration conf) {
+	public static void updateClientConstants(HashMap<Long, String> nodeMap, CrailConfiguration conf) throws IOException {
 
 		String arg = get(conf, DATA_PATH_KEY);
 		if (arg != null) {
@@ -98,6 +118,53 @@ public class BlkDevStorageConstants {
 		if (arg != null) {
 			STORAGE_LIMIT = Long.parseLong(arg);
 		}
+
+		/*
+         * Read the comma seperated lists of virtual device paths and their corresponding datanodes
+         * (IP/ports) from the configuration file, creating a map from the key (IP/port) to virtual
+         * device path. This is map is then consulted to identify the virtual device to when an Endpoint
+         * is created.
+         */
+		StringTokenizer tokenizer = new StringTokenizer(BlkDevStorageConstants.DATA_PATH, ",");
+		if (!tokenizer.hasMoreTokens()){
+			throw new IOException("No data paths defined!");
+		}
+
+		// read the list of virtual device paths
+		List<String> devList= new ArrayList();
+		while (tokenizer.hasMoreTokens()) {
+			String devName = tokenizer.nextToken();
+			devList.add(devName);
+		}
+
+		// read the list of ip/ports
+		tokenizer = new StringTokenizer(BlkDevStorageConstants.DATA_IP_PORT, ",");
+		if (!tokenizer.hasMoreTokens()){
+			throw new IOException("No IP/ports defined!");
+		}
+
+		List<Long> hashList = new ArrayList();
+		while (tokenizer. hasMoreTokens()) {
+			Long key = convertIPPortToKey(tokenizer.nextToken());
+			hashList.add(key);
+		}
+
+		if (hashList.size() != devList.size()){
+			throw new IOException("Device and ip/port list must be the same size" +
+				hashList.size() + ":" + devList.size());
+		}
+
+		// Add the tuples into the hashMap
+		for (int i = 0; i <devList.size(); i++) {
+			Long hash = hashList.get(i);
+			String devName = devList.get(i);
+			nodeMap.put(hash,devName);
+		}
+
+		if (nodeMap.size() == 0) {
+			throw new IOException("Need at least one BlkDev target ip/port list must be the same size" +
+					hashList.size() + ":" + devList.size());
+		}
 	}
 
 	/*
@@ -105,9 +172,9 @@ public class BlkDevStorageConstants {
 	 */
 	public static void updateTargetConstants(CrailConfiguration conf) {
 		
-		String arg = get(conf, STORAGE_BLKDEV_INTERFACE_KEY);
+		String arg = get(conf, STORAGE_BLKDEV_IP_KEY);
 		if (arg != null) {
-			STORAGE_BLKDEV_INTERFACE = arg;
+			STORAGE_BLKDEV_IP = arg;
 		}
 		
 		arg = get(conf, STORAGE_BLKDEV_PORT_KEY);
@@ -124,7 +191,6 @@ public class BlkDevStorageConstants {
 		if (arg != null) {
 			ALLOCATION_SIZE = Long.parseLong(arg);
 		}
-		
 	}
 
 	public static void printClientConf(Logger logger) {
@@ -137,7 +203,7 @@ public class BlkDevStorageConstants {
 	public static void printTargetConf(Logger logger) {
 		logger.info(fullKey(STORAGE_SIZE_KEY) + " " + STORAGE_SIZE);
 		logger.info(fullKey(ALLOCATION_SIZE_KEY) + " " + ALLOCATION_SIZE);
-		logger.info(fullKey(STORAGE_BLKDEV_INTERFACE_KEY) + " " + STORAGE_BLKDEV_INTERFACE);
+		logger.info(fullKey(STORAGE_BLKDEV_IP_KEY) + " " + STORAGE_BLKDEV_IP);
 		logger.info(fullKey(STORAGE_BLKDEV_PORT_KEY) + " " + STORAGE_BLKDEV_PORT);
 	}
 

--- a/src/main/java/com/ibm/crail/storage/blkdev/BlkDevStorageConstants.java
+++ b/src/main/java/com/ibm/crail/storage/blkdev/BlkDevStorageConstants.java
@@ -120,11 +120,11 @@ public class BlkDevStorageConstants {
 		}
 
 		/*
-         * Read the comma seperated lists of virtual device paths and their corresponding datanodes
-         * (IP/ports) from the configuration file, creating a map from the key (IP/port) to virtual
-         * device path. This is map is then consulted to identify the virtual device to when an Endpoint
-         * is created.
-         */
+		 * Read the comma seperated lists of virtual device paths and their corresponding datanodes
+		 * (IP/ports) from the configuration file, creating a map from the key (IP/port) to virtual
+		 * device path. This is map is then consulted to identify the virtual device to when an Endpoint
+		 * is created.
+		 */
 		StringTokenizer tokenizer = new StringTokenizer(BlkDevStorageConstants.DATA_PATH, ",");
 		if (!tokenizer.hasMoreTokens()){
 			throw new IOException("No data paths defined!");

--- a/src/main/java/com/ibm/crail/storage/blkdev/BlkDevStorageConstants.java
+++ b/src/main/java/com/ibm/crail/storage/blkdev/BlkDevStorageConstants.java
@@ -32,17 +32,38 @@ public class BlkDevStorageConstants {
 
 	private final static String PREFIX = "crail.storage.blkdev";
 
-	public static final String STORAGE_LIMIT_KEY = "storagelimit";
-	public static long STORAGE_LIMIT = 1073741824; /* 1GB */
+	// target:interface to access storage device
+	public static final String STORAGE_BLKDEV_INTERFACE_KEY = "interface";
+	public static String STORAGE_BLKDEV_INTERFACE = "eth5";
 
+	// target port to access storage device
+	public static final String STORAGE_BLKDEV_PORT_KEY = "port";
+	public static int STORAGE_BLKDEV_PORT  = 12345;
+
+	// target: size of storage path
+	public static final String STORAGE_SIZE_KEY = "storagesize";
+	public static long STORAGE_SIZE = 1073741824; /* 1GB */
+
+	// target allocation unit size
 	public static final String ALLOCATION_SIZE_KEY = "allocationsize";
-	public static long ALLOCATION_SIZE = 1073741824; /* 1GB */
+	public static long ALLOCATION_SIZE = 1048576; /* 1MB */
 
+	// client Blk-Dev datanode list (device path)
 	public static final String DATA_PATH_KEY = "datapath";
 	public static String DATA_PATH;
 
+	// client: Blk-dev datanode list (ip/port)
+	public static final String DATA_IP_PORT_KEY = "dataipport";
+	public static String DATA_IP_PORT;
+
+	// client
 	public static final String QUEUE_DEPTH_KEY = "queuedepth";
 	public static int QUEUE_DEPTH = 16;
+
+	// client: total size of all Block Devices
+	public static final String STORAGE_LIMIT_KEY = "storagelimit";
+	public static long STORAGE_LIMIT = 1073741824; /* 1GB */
+
 
 	private static String fullKey(String key) {
 		return PREFIX + "." + key;
@@ -52,45 +73,84 @@ public class BlkDevStorageConstants {
 		return conf.get(fullKey(key));
 	}
 
-	public static void updateConstants(CrailConfiguration conf) {
-		String arg = get(conf, STORAGE_LIMIT_KEY);
-		if (arg != null) {
-			STORAGE_LIMIT = Long.parseLong(arg);
-		}
+	/*
+	 * Called only from the client side to map device names to block
+	 * device servers.
+	 */
+	public static void updateClientConstants(CrailConfiguration conf) {
 
-		arg = get(conf, ALLOCATION_SIZE_KEY);
-		if (arg != null) {
-			ALLOCATION_SIZE = Long.parseLong(arg);
-		}
-
-		arg = get(conf, DATA_PATH_KEY);
+		String arg = get(conf, DATA_PATH_KEY);
 		if (arg != null) {
 			DATA_PATH = arg;
+		}
+
+		arg = get(conf, DATA_IP_PORT_KEY);
+		if (arg != null) {
+			DATA_IP_PORT= arg;
 		}
 
 		arg = get(conf, QUEUE_DEPTH_KEY);
 		if (arg != null) {
 			QUEUE_DEPTH = Integer.parseInt(arg);
 		}
+
+		arg = get(conf, STORAGE_LIMIT_KEY);
+		if (arg != null) {
+			STORAGE_LIMIT = Long.parseLong(arg);
+		}
+	}
+
+	/*
+	 * Called only from the target size 
+	 */
+	public static void updateTargetConstants(CrailConfiguration conf) {
+		
+		String arg = get(conf, STORAGE_BLKDEV_INTERFACE_KEY);
+		if (arg != null) {
+			STORAGE_BLKDEV_INTERFACE = arg;
+		}
+		
+		arg = get(conf, STORAGE_BLKDEV_PORT_KEY);
+		if (arg != null) {
+			STORAGE_BLKDEV_PORT = Integer.parseInt(arg);
+		}
+
+		arg = get(conf, STORAGE_SIZE_KEY);
+		if (arg != null) {
+			STORAGE_SIZE = Long.parseLong(arg);
+		}
+
+		arg = get(conf, ALLOCATION_SIZE_KEY);
+		if (arg != null) {
+			ALLOCATION_SIZE = Long.parseLong(arg);
+		}
+		
+	}
+
+	public static void printClientConf(Logger logger) {
+		logger.info(fullKey(DATA_PATH_KEY) + " " + DATA_PATH);
+		logger.info(fullKey(DATA_IP_PORT_KEY) + " " + DATA_IP_PORT);
+		logger.info(fullKey(QUEUE_DEPTH_KEY) + " " + QUEUE_DEPTH);
+		logger.info(fullKey(STORAGE_LIMIT_KEY) + " " + STORAGE_LIMIT);
+	}
+	
+	public static void printTargetConf(Logger logger) {
+		logger.info(fullKey(STORAGE_SIZE_KEY) + " " + STORAGE_SIZE);
+		logger.info(fullKey(ALLOCATION_SIZE_KEY) + " " + ALLOCATION_SIZE);
+		logger.info(fullKey(STORAGE_BLKDEV_INTERFACE_KEY) + " " + STORAGE_BLKDEV_INTERFACE);
+		logger.info(fullKey(STORAGE_BLKDEV_PORT_KEY) + " " + STORAGE_BLKDEV_PORT);
 	}
 
 	public static void verify() throws IOException {
 		if (ALLOCATION_SIZE % CrailConstants.BLOCK_SIZE != 0){
 			throw new IOException("allocationsize must be multiple of crail.blocksize");
 		}
-		if (STORAGE_LIMIT % ALLOCATION_SIZE != 0){
-			throw new IOException("storageLimit must be multiple of allocationSize");
+		if (STORAGE_SIZE % ALLOCATION_SIZE != 0){
+			throw new IOException("storageSize must be multiple of allocationSize");
 		}
 	}
 
-	public static void printConf(Logger logger) {
-		logger.info(fullKey(STORAGE_LIMIT_KEY) + " " + STORAGE_LIMIT);
-		logger.info(fullKey(ALLOCATION_SIZE_KEY) + " " + ALLOCATION_SIZE);
-		logger.info(fullKey(DATA_PATH_KEY) + " " + DATA_PATH);
-		logger.info(fullKey(QUEUE_DEPTH_KEY) + " " + QUEUE_DEPTH);
-	}
-
 	public static void init(CrailConfiguration conf, String[] args) throws Exception{
-		BlkDevStorageConstants.updateConstants(conf);
+		BlkDevStorageConstants.updateTargetConstants(conf);
 	}
 }

--- a/src/main/java/com/ibm/crail/storage/blkdev/BlkDevStorageServer.java
+++ b/src/main/java/com/ibm/crail/storage/blkdev/BlkDevStorageServer.java
@@ -34,9 +34,12 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 public class BlkDevStorageServer implements StorageServer {
 	private static final Logger LOG = CrailUtils.getLogger();
@@ -47,7 +50,6 @@ public class BlkDevStorageServer implements StorageServer {
 	private boolean initialized = false;
 	private long addr;
 	private long alignedSize;
-	private BlkDevStorageEndpoint endPoint;
 
 	public BlkDevStorageServer() throws Exception {
 
@@ -57,27 +59,41 @@ public class BlkDevStorageServer implements StorageServer {
 			throw new IOException("BlkDevStorageTier already initialized");
 		}
 		initialized = true;
-		BlkDevStorageConstants.init(crailConfiguration, args);
-		LOG.info("initalizing block device datanode");
-		// We do not support multiple block devices yet
-		InetAddress address = InetAddress.getLoopbackAddress();
-		int port = 12345;
 
-		storageAddr = new InetSocketAddress(address, port);
-		String directory = BlkDevStorageConstants.DATA_PATH;
-		path = FileSystems.getDefault().getPath(directory);
-		if (!Files.exists(path)) {
-			throw new IllegalArgumentException("BlkDev path does not exists!");
-		}
+		BlkDevStorageConstants.init(crailConfiguration, args);
+
+		storageAddr = getDataNodeAddress();
 		isAlive = true;
-		alignedSize = BlkDevStorageConstants.STORAGE_LIMIT - (BlkDevStorageConstants.STORAGE_LIMIT % BlkDevStorageConstants.ALLOCATION_SIZE);
-		endPoint = new BlkDevStorageEndpoint();
+		alignedSize = BlkDevStorageConstants.STORAGE_SIZE -
+				(BlkDevStorageConstants.STORAGE_SIZE % BlkDevStorageConstants.ALLOCATION_SIZE);
 		addr = 0;
+	}
+
+	public static InetSocketAddress getDataNodeAddress() throws IOException {
+		String ifname = BlkDevStorageConstants.STORAGE_BLKDEV_INTERFACE;
+		int port = BlkDevStorageConstants.STORAGE_BLKDEV_PORT;
+		
+		NetworkInterface netif = NetworkInterface.getByName(ifname);
+		if (netif == null){
+			return null;
+		}
+
+		List<InterfaceAddress> addresses = netif.getInterfaceAddresses();
+		InetAddress addr = null;
+		for (InterfaceAddress address: addresses){
+			if (address.getBroadcast() != null){
+				InetAddress _addr = address.getAddress();
+				addr = _addr;
+			}
+		}		
+
+		InetSocketAddress inetAddr = new InetSocketAddress(addr, port);
+		return inetAddr;
 	}
 
 	@Override
 	public void printConf(Logger log) {
-		BlkDevStorageConstants.printConf(log);
+		BlkDevStorageConstants.printTargetConf(log);
 	}
 
 	@Override

--- a/src/main/java/com/ibm/crail/storage/blkdev/BlkDevStorageServer.java
+++ b/src/main/java/com/ibm/crail/storage/blkdev/BlkDevStorageServer.java
@@ -32,14 +32,8 @@ import com.ibm.crail.utils.CrailUtils;
 import org.slf4j.Logger;
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.InterfaceAddress;
-import java.net.NetworkInterface;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 
 public class BlkDevStorageServer implements StorageServer {
 	private static final Logger LOG = CrailUtils.getLogger();
@@ -62,33 +56,15 @@ public class BlkDevStorageServer implements StorageServer {
 
 		BlkDevStorageConstants.init(crailConfiguration, args);
 
-		storageAddr = getDataNodeAddress();
+		String ipAddr = BlkDevStorageConstants.STORAGE_BLKDEV_IP;
+		int port = BlkDevStorageConstants.STORAGE_BLKDEV_PORT;
+		storageAddr = new InetSocketAddress(ipAddr, port);
+
 		isAlive = true;
 		alignedSize = BlkDevStorageConstants.STORAGE_SIZE -
 				(BlkDevStorageConstants.STORAGE_SIZE % BlkDevStorageConstants.ALLOCATION_SIZE);
 		addr = 0;
-	}
 
-	public static InetSocketAddress getDataNodeAddress() throws IOException {
-		String ifname = BlkDevStorageConstants.STORAGE_BLKDEV_INTERFACE;
-		int port = BlkDevStorageConstants.STORAGE_BLKDEV_PORT;
-		
-		NetworkInterface netif = NetworkInterface.getByName(ifname);
-		if (netif == null){
-			return null;
-		}
-
-		List<InterfaceAddress> addresses = netif.getInterfaceAddresses();
-		InetAddress addr = null;
-		for (InterfaceAddress address: addresses){
-			if (address.getBroadcast() != null){
-				InetAddress _addr = address.getAddress();
-				addr = _addr;
-			}
-		}		
-
-		InetSocketAddress inetAddr = new InetSocketAddress(addr, port);
-		return inetAddr;
 	}
 
 	@Override

--- a/src/main/java/com/ibm/crail/storage/blkdev/client/BlkDevStorageEndpoint.java
+++ b/src/main/java/com/ibm/crail/storage/blkdev/client/BlkDevStorageEndpoint.java
@@ -50,11 +50,11 @@ public class BlkDevStorageEndpoint implements StorageEndpoint {
 	private final ThreadLocal<AsynchronousIOOperationArray> writeOp;
 	private final BufferCache cache;
 
-	public BlkDevStorageEndpoint() throws IOException {
+	public BlkDevStorageEndpoint(String devName) throws IOException {
 		if (BlkDevStorageUtils.fileBlockOffset(CrailConstants.DIRECTORY_RECORD) != 0) {
 			throw new IllegalArgumentException("Block device requires directory record size to be block aligned");
 		}
-		Path path = FileSystems.getDefault().getPath(BlkDevStorageConstants.DATA_PATH);
+		Path path = FileSystems.getDefault().getPath(devName);
 		this.file = new File(path, OpenOption.READ, OpenOption.WRITE, OpenOption.DIRECT, OpenOption.SYNC);
 		this.concurrentOps = new Semaphore(BlkDevStorageConstants.QUEUE_DEPTH, true);
 		this.queue = new AsynchronousIOQueue(BlkDevStorageConstants.QUEUE_DEPTH);


### PR DESCRIPTION
This pull request attempts to address issue #1.

I think the README.md was previously edited on a Windows box with linefeeds, causing the ^M diffs. Those are removed.

This commit relies  https://github.com/zrlio/crail/pull/43 to provide arbitrary hashcode calculation.

The main change here is that a blkdev target specifies its IP (through interface) and port. It registers that with the namenode, as opposed the unused localhost:port before.

The client now must specifiy a tuple per blkdev, consisting of it's ip:port and the local logical device name. It then creates a hashmap of this ip/port (hashcode) to logical dev name. When the namenode says to write a block to a given ip:port, the client can look the corresponding hashcode up in the new hashtable to determine which local logical device to use.