### PR TITLE
[Endpoint] increase result array size for RMW

### DIFF
--- a/src/main/java/com/ibm/crail/storage/blkdev/client/BlkDevStorageEndpoint.java
+++ b/src/main/java/com/ibm/crail/storage/blkdev/client/BlkDevStorageEndpoint.java
@@ -65,7 +65,7 @@ public class BlkDevStorageEndpoint implements StorageEndpoint {
 		this.file = new File(path, OpenOption.READ, OpenOption.WRITE, OpenOption.DIRECT, OpenOption.SYNC);
 		this.concurrentOps = new Semaphore(BlkDevStorageConstants.QUEUE_DEPTH, true);
 		this.queue = new AsynchronousIOQueue(BlkDevStorageConstants.QUEUE_DEPTH);
-		this.results = new ArrayBlockingQueue(BlkDevStorageConstants.QUEUE_DEPTH);
+		this.results = new ArrayBlockingQueue(BlkDevStorageConstants.QUEUE_DEPTH*2);
 		int i = results.remainingCapacity();
 		while (i-- > 0) {
 			try {


### PR DESCRIPTION
In case a lot of operations in the queue are RMW every poll/signal
creates new IO requests. If we are out of requests we poll again.
Eventually we will run out of result arrays to poll to since we
only have enough for each request but don't take RMW operations
into account.

Signed-off-by: Jonas Pfefferle <pepperjo@japf.ch>